### PR TITLE
Allow objectMode catstreams. Fix example in README. Improve logging in example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,57 +6,69 @@ N other streams.
 
 ## Example
 
-    $ cat examples/catstreams.js 
-    /*
-     * examples/catstreams.js: basic CatStreams example
-     */
-    
-    var mod_restify = require('restify');
-    var mod_bunyan = require('bunyan');
-    var HttpStream = require('httpstream');
-    var CatStreams = require('../lib/catstreams');
-    
-    var log = new mod_bunyan({
-        'name': 'example',
-        'level': 'warn',
-        'serializers': {}
-    });
-    
-    var client = mod_restify.createClient({
-        'log': log,
-        'url': 'https://us-east.manta.joyent.com'
-    });
-    
-    var stream = new CatStreams({
-        'log': log,
-        'perRequestBuffer': 10 * 1024 * 1024,
-        'maxConcurrency': 2
-    });
-    
-    stream.cat(function (options) {
-    	return (new HttpStream({
-    	    'client': client,
-    	    'path': '/manta/public/sdks/node-manta.tar.gz',
-    	    'log': log,
-    	    'highWaterMark': options['highWaterMark']
-    	}));
-    });
-    
-    var sum = 0;
-    console.log('fetching ... ');
-    stream.on('data', function (c) { sum += c.length; });
-    stream.on('end', function () {
-    	console.log('fetched %d bytes', sum);
-    	client.close();
-    });
+```bash
+$ cat examples/catstreams.js
+/*
+ * examples/catstreams.js: basic CatStreams example
+ */
 
+var mod_restify = require('restify');
+var mod_bunyan = require('bunyan');
+var HttpStream = require('httpstream');
+var CatStreams = require('../lib/catstreams');
 
-    $ mls -l /manta/public/sdks/node-manta.tar.gz
-    -rwxr-xr-x 1 manta       2697998 Jul 22 15:52 node-manta.tar.gz
+var log = new mod_bunyan({
+    'name': 'example',
+    'level': 'warn',
+    'serializers': mod_restify.bunyan.serializers
+});
 
-    $ node examples/catstream.js
-    fetching ... 
-    fetched 5395996 bytes
+var client = mod_restify.createClient({
+    'log': log,
+    'url': 'https://us-east.manta.joyent.com'
+});
+
+var stream = new CatStreams({
+    'log': log,
+    'perRequestBuffer': 10 * 1024 * 1024,
+    'maxConcurrency': 2
+});
+
+stream.cat(function (options) {
+	return (new HttpStream({
+	    'client': client,
+	    'path': '/manta/public/sdks/node-manta.tar.gz',
+	    'log': log,
+	    'highWaterMark': options['highWaterMark']
+	}));
+});
+
+stream.cat(function (options) {
+	return (new HttpStream({
+	    'client': client,
+	    'path': '/manta/public/sdks/node-manta.tar.gz',
+	    'log': log,
+	    'highWaterMark': options['highWaterMark']
+	}));
+});
+
+stream.cat(null);
+
+var sum = 0;
+console.log('fetching ... ');
+stream.on('data', function (c) { sum += c.length; });
+stream.on('end', function () {
+	console.log('fetched %d bytes', sum);
+	client.close();
+});
+
+$ mls -l /manta/public/sdks/node-manta.tar.gz
+-rwxr-xr-x 1 manta       2697998 Jul 22 15:52 node-manta.tar.gz
+
+$ node examples/catstream.js
+fetching ...
+fetched 5395996 bytes
+```
 
 
 ## Contributions

--- a/README.md
+++ b/README.md
@@ -6,69 +6,67 @@ N other streams.
 
 ## Example
 
-```bash
-$ cat examples/catstreams.js
-/*
- * examples/catstreams.js: basic CatStreams example
- */
+    $ cat examples/catstreams.js
+    /*
+     * examples/catstreams.js: basic CatStreams example
+     */
 
-var mod_restify = require('restify');
-var mod_bunyan = require('bunyan');
-var HttpStream = require('httpstream');
-var CatStreams = require('../lib/catstreams');
+    var mod_restify = require('restify');
+    var mod_bunyan = require('bunyan');
+    var HttpStream = require('httpstream');
+    var CatStreams = require('../lib/catstreams');
 
-var log = new mod_bunyan({
-    'name': 'example',
-    'level': 'warn',
-    'serializers': mod_restify.bunyan.serializers
-});
+    var log = new mod_bunyan({
+        'name': 'example',
+        'level': 'warn',
+        'serializers': mod_restify.bunyan.serializers
+    });
 
-var client = mod_restify.createClient({
-    'log': log,
-    'url': 'https://us-east.manta.joyent.com'
-});
+    var client = mod_restify.createClient({
+        'log': log,
+        'url': 'https://us-east.manta.joyent.com'
+    });
 
-var stream = new CatStreams({
-    'log': log,
-    'perRequestBuffer': 10 * 1024 * 1024,
-    'maxConcurrency': 2
-});
+    var stream = new CatStreams({
+        'log': log,
+        'perRequestBuffer': 10 * 1024 * 1024,
+        'maxConcurrency': 2
+    });
 
-stream.cat(function (options) {
-	return (new HttpStream({
-	    'client': client,
-	    'path': '/manta/public/sdks/node-manta.tar.gz',
-	    'log': log,
-	    'highWaterMark': options['highWaterMark']
-	}));
-});
+    stream.cat(function (options) {
+    	return (new HttpStream({
+    	    'client': client,
+    	    'path': '/manta/public/sdks/node-manta.tar.gz',
+    	    'log': log,
+    	    'highWaterMark': options['highWaterMark']
+    	}));
+    });
 
-stream.cat(function (options) {
-	return (new HttpStream({
-	    'client': client,
-	    'path': '/manta/public/sdks/node-manta.tar.gz',
-	    'log': log,
-	    'highWaterMark': options['highWaterMark']
-	}));
-});
+    stream.cat(function (options) {
+    	return (new HttpStream({
+    	    'client': client,
+    	    'path': '/manta/public/sdks/node-manta.tar.gz',
+    	    'log': log,
+    	    'highWaterMark': options['highWaterMark']
+    	}));
+    });
 
-stream.cat(null);
+    stream.cat(null);
 
-var sum = 0;
-console.log('fetching ... ');
-stream.on('data', function (c) { sum += c.length; });
-stream.on('end', function () {
-	console.log('fetched %d bytes', sum);
-	client.close();
-});
+    var sum = 0;
+    console.log('fetching ... ');
+    stream.on('data', function (c) { sum += c.length; });
+    stream.on('end', function () {
+    	console.log('fetched %d bytes', sum);
+    	client.close();
+    });
 
-$ mls -l /manta/public/sdks/node-manta.tar.gz
--rwxr-xr-x 1 manta       2697998 Jul 22 15:52 node-manta.tar.gz
+    $ mls -l /manta/public/sdks/node-manta.tar.gz
+    -rwxr-xr-x 1 manta       2697998 Jul 22 15:52 node-manta.tar.gz
 
-$ node examples/catstream.js
-fetching ...
-fetched 5395996 bytes
-```
+    $ node examples/catstream.js
+    fetching ...
+    fetched 5395996 bytes
 
 
 ## Contributions

--- a/examples/catstreams.js
+++ b/examples/catstreams.js
@@ -9,8 +9,8 @@ var CatStreams = require('../lib/catstreams');
 
 var log = new mod_bunyan({
     'name': 'example',
-    'level': 'warn',
-    'serializers': {}
+    'level': process.env['LOG_LEVEL'] || 'warn',
+    'serializers': mod_restify.bunyan.serializers
 });
 
 var client = mod_restify.createClient({

--- a/lib/catstreams.js
+++ b/lib/catstreams.js
@@ -30,6 +30,9 @@ module.exports = CatStreams;
  *
  *    maxConcurrency	max number of streams outstanding
  *
+ *    objectMode	whether stream items are objects (optional,
+ *    			default false)
+ *
  * To append a resource, callers invoke cat(func), where "func" will be
  * invoked as "func(options)".  "func" should return the stream to be appended.
  * "options" contains options for passing through to the Readable stream
@@ -81,7 +84,9 @@ function CatStreams(options)
 	this.cs_nstarted = 0;		/* count of resources started */
 	this.cs_ndone = 0;		/* count of resources done */
 
-	mod_stream.PassThrough.call(this);
+	mod_stream.PassThrough.call(this,
+	    { 'objectMode': options.hasOwnProperty('objectMode')
+	    ? options.objectMode : false });
 }
 
 mod_util.inherits(CatStreams, mod_stream.PassThrough);

--- a/lib/catstreams.js
+++ b/lib/catstreams.js
@@ -30,8 +30,8 @@ module.exports = CatStreams;
  *
  *    maxConcurrency	max number of streams outstanding
  *
- *    objectMode	whether stream items are objects (optional,
- *    			default false)
+ *    streamOptions	options to pass to the underlying Stream,
+ *    			e.g. objectMode
  *
  * To append a resource, callers invoke cat(func), where "func" will be
  * invoked as "func(options)".  "func" should return the stream to be appended.
@@ -84,9 +84,7 @@ function CatStreams(options)
 	this.cs_nstarted = 0;		/* count of resources started */
 	this.cs_ndone = 0;		/* count of resources done */
 
-	mod_stream.PassThrough.call(this,
-	    { 'objectMode': options.hasOwnProperty('objectMode')
-	    ? options.objectMode : false });
+	mod_stream.PassThrough.call(this, options.streamOptions);
 }
 
 mod_util.inherits(CatStreams, mod_stream.PassThrough);


### PR DESCRIPTION
Mainly I want to use catstreams (in sesat) with objectMode streams.

I also got surprised for a while attempting to grok from the example in the README... which didn't match what was in the actual example file: no second and third `stream.cat` calls.

Also, when I was playing with the logging level in the example, it blew up serializing a huge `client_res` object in the restify client. Adding `restify.bunyan.serializers` fixes that.
